### PR TITLE
Update the CodeQL GitHub Action to v3, per https://github.blog/change…

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,7 @@ jobs:
           ./configure --with-modules=mod_tar
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           config-file: proftpd-mod_tar/.codeql.yml
@@ -68,7 +68,7 @@ jobs:
           make
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"
           checkout_path: proftpd-mod_tar


### PR DESCRIPTION
…log/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/